### PR TITLE
ci: enable fork PR checks via pull_request_target

### DIFF
--- a/.github/workflows/backend-ci-pr-target.yml
+++ b/.github/workflows/backend-ci-pr-target.yml
@@ -1,0 +1,35 @@
+name: backend-ci (fork PRs)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head (no creds)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f backend/requirements.txt ]; then pip install -r backend/requirements.txt; fi
+          if [ -f backend/requirements-dev.txt ]; then pip install -r backend/requirements-dev.txt; fi
+
+      - name: Run tests
+        working-directory: backend
+        run: |
+          python -m pytest -q


### PR DESCRIPTION
Adds a minimal `pull_request_target` GitHub Actions workflow so PRs from forks (including #6) get CI status checks.

Security notes:
- Uses `permissions: contents: read`
- Checks out `${{ github.event.pull_request.head.sha }}`
- `persist-credentials: false`
- No secrets used

Once merged, PR #6 should show checks and be easier to review/merge.